### PR TITLE
Display events split into "Upcoming" and "Past"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Kuberoke Website
 
 ## Development
+
+### Initialise theme
+`git submodule add -b main https://github.com/nunocoracao/blowfish.git themes/blowfish`
+
 ### Run local dev server
 `docker run --rm -it -v $(pwd):/src -p 1313:1313 klakegg/hugo:latest server`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 `git submodule add -b main https://github.com/nunocoracao/blowfish.git themes/blowfish`
 
 ### Run local dev server
-`docker run --rm -it -v $(pwd):/src -p 1313:1313 klakegg/hugo:latest server`
+In development mode, drafts are served
+`docker run --rm -it -v $(pwd):/src -p 1313:1313 klakegg/hugo:latest serve -D`
 
 ### Build page once
 `docker run --rm -it -v $(pwd):/src -p 1313:1313 klakegg/hugo:latest`

--- a/content/events/fall-party-chicago-2023/index.md
+++ b/content/events/fall-party-chicago-2023/index.md
@@ -3,7 +3,6 @@ title: " Kuberoke Fall Party Chicago"
 date: 2023-11-07
 authors:
   - "dave"
-draft: true
 ---
 KubeCon + CloudNativeCon is coming to Chicago and to celebrate the occasion, we are hosting a Karaoke party on **Tuesday November 7, 9pm - 2am** at Chicago's premier Karaoke bar, Brando's Speakeasy.
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2970.7240802035885!2d-87.63158542367218!3d41.87728256546486!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880e2cbd3a474423%3A0xaef5b2fc61bc062c!2sBrando&#39;s%20Speakeasy!5e0!3m2!1sen!2sus!4v1695670979244!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>

--- a/content/events/fall-party-slc-2024/index.md
+++ b/content/events/fall-party-slc-2024/index.md
@@ -1,0 +1,8 @@
+---
+title: " Kuberoke Fall Party Salt Lake City"
+date: TBD
+authors:
+  - "lian"
+draft: true
+---
+KubeCon + CloudNativeCon is coming to Salt Lake City and to celebrate the occasion, we are hosting a Karaoke party.

--- a/content/events/spring-party-amsterdam-2023/index.md
+++ b/content/events/spring-party-amsterdam-2023/index.md
@@ -3,7 +3,6 @@ title: " Kuberoke Spring Party Amsterdam"
 date: 2023-04-19
 authors:
   - "lian"
-draft: true
 ---
 KubeCon + CloudNativeCon is coming to beautiful Amsterdam and to celebrate the occasion, we are hosting a Karaoke party on **Wednesday April 19, 9pm - 1am** at Amsterdam's premier Karaoke bar, KTV Bar.
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2435.691042140049!2d4.897678315850254!3d52.37602197978714!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c609b9cbcf2301%3A0x97b875ed29f9c2b0!2sKTV%20Bar!5e0!3m2!1sen!2snl!4v1675784699651!5m2!1sen!2snl" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>

--- a/content/events/spring-party-paris-2024/index.md
+++ b/content/events/spring-party-paris-2024/index.md
@@ -3,7 +3,6 @@ title: "Kuberoke Spring Party Paris"
 date: 2024-03-20
 authors:
   - "dave"
-draft: false
 ---
 KubeCon + CloudNativeCon is coming to Paris and to celebrate the occasion, we are hosting a Karaoke party on **Wednesday March 20, 9pm - 1am** at KaraFun Bar Paris.
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.345731628021!2d2.347888712625055!3d48.870685399720735!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47e66f2bf110a499%3A0x86ae8d7be422c7c8!2sKaraFun%20Paris!5e0!3m2!1sen!2sus!4v1708800983108!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -61,7 +61,7 @@ sharing:
   twitter: "Tweet on Twitter"
 
 shortcode:
-  recent_articles: "Upcoming"
+  recent_articles: ""
 
 recent:
   show_more: "Show More"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -63,17 +63,34 @@
     {{ $groupByYear := .Params.groupByYear | default ($.Site.Params.list.groupByYear | default false) }}
 
     {{ if not $cardView }}
-
+    
     <section class="space-y-10 w-full">
+      <h2 class="mt-8 text-2xl font-extrabold mb-10">Upcoming</h2>
       {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-      {{ if $groupByYear }}
+        {{ if $groupByYear }}
       <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-        {{ .Key }}
+          {{ .Key }}
       </h2>
+        {{ end }}
+        {{ range .Pages }}
+          {{ if not (.Params.date.Before (time.AsTime time.Now)) }}
+            {{ partial "article-link/simple.html" . }}
+          {{ end }}
+        {{ end }}
       {{ end }}
-      {{ range .Pages }}
-      {{ partial "article-link/simple.html" . }}
-      {{ end }}
+
+      <h2 class="mt-8 text-2xl font-extrabold mb-10">Past</h2>
+      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+        {{ if $groupByYear }}
+      <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+          {{ .Key }}
+      </h2>
+        {{ end }}
+        {{ range .Pages }}
+          {{ if .Params.date.Before (time.AsTime time.Now) }}
+            {{ partial "article-link/simple.html" . }}
+          {{ end }}
+        {{ end }}
       {{ end }}
     </section>
 

--- a/layouts/partials/recent-articles/list.html
+++ b/layouts/partials/recent-articles/list.html
@@ -1,0 +1,18 @@
+{{ $recentArticles := 5 }}
+{{ $recentArticles = .Site.Params.homepage.showRecentItems }}
+
+<section class="space-y-10 w-full">
+  <h2 class="mt-8 text-2xl font-extrabold mb-10">Upcoming</h2>
+  {{ range first $recentArticles (.Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections)).Pages }}
+    {{ if not (.Params.date.Before (time.AsTime time.Now)) }}
+      {{ partial "article-link/simple.html" . }}
+    {{ end }}
+  {{ end }}
+  
+  <h2 class="mt-8 text-2xl font-extrabold mb-10">Past</h2>
+  {{ range first $recentArticles (.Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections)).Pages }}
+    {{ if .Params.date.Before (time.AsTime time.Now) }}
+      {{ partial "article-link/simple.html" . }}
+    {{ end }}
+  {{ end }}
+</section>


### PR DESCRIPTION
In the past we always had to put old events in draft to highlight the current event.
This PR changes the layout to show the next upcoming events first before past events.